### PR TITLE
feat(devops): implementación de notificaciones CI/CD vía WhatsApp Bot #10

### DIFF
--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -141,7 +141,23 @@ tests/
 - [🤖 **Jenkins Pipelines**](./jenkins/README.md) - Configuración detallada de Jenkinsfiles
 - [📖 **Jenkins Paso a Paso**](./jenkins/CONFIGURACION_PASO_A_PASO.md) - Guía rápida de configuración y desbloqueo
 - [🏗️ **Infraestructura**](../infrastructure/README.md) - Terraform, Docker, y arquitectura
+- [📱 **Notificaciones de WhatsApp**](./jenkins/NOTIFICACIONES_WHATSAPP.md) - Configuración del bot de alertas
 
 ---
+
+## 📱 Notificaciones de WhatsApp (WAHA)
+
+Hemos implementado un sistema de notificaciones en tiempo real para alertar al equipo sobre el estado de los builds.
+
+### **¿Cómo funciona?**
+1.  **WAHA (WhatsApp HTTP API)** corre como un contenedor Docker en la infraestructura.
+2.  Al finalizar un build, Jenkins ejecuta un script que envía un mensaje formateado al grupo de WhatsApp.
+3.  **No invasivo**: La lógica vive solo en el servidor y no afecta al código de la App (APK).
+
+### **Componentes:**
+- **Script**: `ci-cd/jenkins/scripts/notify_whatsapp.sh`
+- **Docker**: Puerto `3000` en la instancia App Server.
+
+📖 **Guía de configuración**: [ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md](./jenkins/NOTIFICACIONES_WHATSAPP.md)
 
 > **⚠️ REGLA DE ORO:** Nunca subas contraseñas o llaves de acceso al repositorio. Jenkins las tomará automáticamente de forma segura desde su propia configuración.

--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -130,12 +130,22 @@ pipeline {
             echo '✅ ¡TODOS LOS COMPONENTES PASARON!'
             echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
             echo '🎉 El proyecto está listo para merge'
+            
+            // Notificación WhatsApp (Issue #10)
+            withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
+                sh './ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS ${BRANCH_NAME}'
+            }
         }
         failure {
             echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
             echo '❌ ALGUNOS COMPONENTES FALLARON'
             echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
             echo '⚠️  Revisa los logs arriba para ver qué falló'
+            
+            // Notificación WhatsApp (Issue #10)
+            withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
+                sh './ci-cd/jenkins/scripts/notify_whatsapp.sh FAILURE ${BRANCH_NAME}'
+            }
         }
         always {
             echo '🧹 Limpiando workspace...'

--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -132,8 +132,14 @@ pipeline {
             echo '🎉 El proyecto está listo para merge'
             
             // Notificación WhatsApp (Issue #10)
-            withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
-                sh './ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS ${BRANCH_NAME}'
+            script {
+                try {
+                    withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
+                        sh './ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS ${BRANCH_NAME}'
+                    }
+                } catch (Exception e) {
+                    echo "⚠️ No se pudo enviar notificación de WhatsApp: ${e.message}"
+                }
             }
         }
         failure {
@@ -143,8 +149,14 @@ pipeline {
             echo '⚠️  Revisa los logs arriba para ver qué falló'
             
             // Notificación WhatsApp (Issue #10)
-            withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
-                sh './ci-cd/jenkins/scripts/notify_whatsapp.sh FAILURE ${BRANCH_NAME}'
+            script {
+                try {
+                    withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
+                        sh './ci-cd/jenkins/scripts/notify_whatsapp.sh FAILURE ${BRANCH_NAME}'
+                    }
+                } catch (Exception e) {
+                    echo "⚠️ No se pudo enviar notificación de WhatsApp: ${e.message}"
+                }
             }
         }
         always {

--- a/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
+++ b/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
@@ -17,13 +17,31 @@ Una vez que el contenedor esté corriendo:
 3. Escanea el código QR que aparece en la terminal.
 
 ## 3. 🔑 Configuración en Jenkins
-Para que Jenkins pueda enviar mensajes, necesita saber a quién enviárselos.
+Para que Jenkins pueda enviar mensajes, necesita el `chatId` real del destinatario (que no es lo mismo que un link de invitación).
 
+### Cómo obtener el `chatId` (ID del Grupo o Chat)
+Una vez vinculado el teléfono, tienes dos formas de obtener el ID:
+
+#### Opción A: Vía Swagger (Recomendado)
+1. Accede a la interfaz de WAHA en tu navegador: `http://[IP-DEL-SERVIDOR]:3005/`
+2. Busca el endpoint **`GET /api/chats`**.
+3. Haz clic en **"Try it out"** y luego en **"Execute"**.
+4. En la respuesta (Response body), busca el nombre de tu grupo o contacto.
+5. Copia el valor de la propiedad `"id"`. 
+   - 👥 Grupos: Tienen el formato `1203630245678@g.us`
+   - 👤 Contactos: Tienen el formato `51987654321@c.us`
+
+#### Opción B: Vía Logs
+1. Ejecuta: `docker logs -f equine-lead-waha`
+2. Escribe cualquier mensaje en el grupo de WhatsApp.
+3. En la terminal verás aparecer un JSON del mensaje recibido. Busca el campo `"from"` o `"chatId"`.
+
+### Configuración de la Credencial
 1. Ir a **Manage Jenkins** > **Credentials**.
 2. Añadir una nueva credencial de tipo **Secret text**:
-   - **ID**: `waha-recipient`
-   - **Secret**: El ID del grupo o número de teléfono (ej: `123456789@c.us` para números o `123456789@g.us` para grupos).
-   - **Description**: ID del destinatario de WhatsApp para EquineLead.
+   - **ID**: `waha-recipient` (Debe ser exactamente este ID).
+   - **Secret**: El `chatId` obtenido en el paso anterior.
+   - **Description**: Recipiente de notificaciones WhatsApp EquineLead.
 
 ## 📝 Notas Técnicas
 - **Transición a Producción**: Cuando dejen de usar `docker-compose.mock.yml`, simplemente copien la definición del servicio `waha` al `docker-compose.yml` final. El script de Jenkins seguirá funcionando igual.

--- a/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
+++ b/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
@@ -1,0 +1,31 @@
+# 📱 Guía de Configuración: Notificaciones de WhatsApp (WAHA)
+
+Esta guía explica cómo configurar el sistema de notificaciones automáticas para Jenkins usando **WAHA (WhatsApp HTTP API)**.
+
+## 1. 🚀 Despliegue del Servicio
+El servicio WAHA debe estar corriendo en la instancia de Oracle Cloud (App Server).
+
+```bash
+cd infrastructure/docker
+docker compose -f docker-compose.mock.yml up -d waha
+```
+
+## 2. 📲 Vinculación de WhatsApp
+Una vez que el contenedor esté corriendo:
+1. Revisa los logs para ver el código QR: `docker logs -f equine-lead-waha`
+2. Abre WhatsApp en tu teléfono -> Dispositivos vinculados -> Vincular un dispositivo.
+3. Escanea el código QR que aparece en la terminal.
+
+## 3. 🔑 Configuración en Jenkins
+Para que Jenkins pueda enviar mensajes, necesita saber a quién enviárselos.
+
+1. Ir a **Manage Jenkins** > **Credentials**.
+2. Añadir una nueva credencial de tipo **Secret text**:
+   - **ID**: `waha-recipient`
+   - **Secret**: El ID del grupo o número de teléfono (ej: `123456789@c.us` para números o `123456789@g.us` para grupos).
+   - **Description**: ID del destinatario de WhatsApp para EquineLead.
+
+## 📝 Notas Técnicas
+- **Transición a Producción**: Cuando dejen de usar `docker-compose.mock.yml`, simplemente copien la definición del servicio `waha` al `docker-compose.yml` final. El script de Jenkins seguirá funcionando igual.
+- El script de notificación se encuentra en: `ci-cd/jenkins/scripts/notify_whatsapp.sh`.
+- La URL por defecto es `http://localhost:3005`. Si Jenkins y WAHA están en servidores distintos, debes actualizar la variable `WAHA_URL` en el script o como variable de entorno en Jenkins.

--- a/ci-cd/jenkins/scripts/notify_whatsapp.sh
+++ b/ci-cd/jenkins/scripts/notify_whatsapp.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# notify_whatsapp.sh
+# Script para enviar notificaciones de Jenkins a través de WAHA (WhatsApp HTTP API)
+
+STATUS=$1
+BRANCH=$2
+PROJECT_NAME=${PROJECT_NAME:-"EquineLead"}
+WAHA_URL=${WAHA_URL:-"http://localhost:3005"}
+WAHA_SESSION=${WAHA_SESSION:-"default"}
+RECIPIENT=${WAHA_RECIPIENT}
+
+if [ -z "$STATUS" ] || [ -z "$BRANCH" ]; then
+    echo "Uso: $0 <STATUS> <BRANCH>"
+    exit 1
+fi
+
+if [ "$STATUS" == "SUCCESS" ]; then
+    ICON="✅"
+    MSG="¡Build Exitoso!"
+elif [ "$STATUS" == "FAILURE" ]; then
+    ICON="❌"
+    MSG="¡Build Fallido!"
+else
+    ICON="⚠️"
+    MSG="Build con estado: $STATUS"
+fi
+
+LAST_COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an')
+MESSAGE="*${ICON} ${PROJECT_NAME} Notification*
+-------------------------
+*Estado:* ${MSG}
+*Rama:* ${BRANCH}
+*Autor:* ${LAST_COMMIT_AUTHOR}
+-------------------------
+_Enviado automáticamente por Jenkins_"
+
+# Enviar vía WAHA API
+curl -X POST "${WAHA_URL}/api/sendText" \
+     -H "Content-Type: application/json" \
+     -d "{
+           \"chatId\": \"${RECIPIENT}\",
+           \"text\": \"${MESSAGE}\",
+           \"session\": \"${WAHA_SESSION}\"
+         }"
+
+echo "Notificación enviada con estado $STATUS"

--- a/infrastructure/docker/docker-compose.mock.yml
+++ b/infrastructure/docker/docker-compose.mock.yml
@@ -24,3 +24,15 @@ services:
     ports:
       - "8080:80"
     restart: always
+
+  # WAHA - WhatsApp HTTP API (Open Source)
+  # Este servicio permite a Jenkins enviar mensajes de WhatsApp
+  waha:
+    image: devlikeapro/waha
+    container_name: equine-lead-waha
+    ports:
+      - "3005:3000"
+    restart: always
+    environment:
+      - WAHA_LOG_LEVEL=info
+      - WAHA_PRINT_QR=true


### PR DESCRIPTION
# 📝 Descripción
Este PR implementa un sistema de notificaciones en tiempo real para alertar al equipo sobre el estado de los builds en Jenkins (Success/Failure) a través de WhatsApp, utilizando la API WAHA.

## 🛠️ Cambios Realizados
**1.  CI/CD:**
- ci-cd/jenkins/scripts/notify_whatsapp.sh
: Script de automatización para el envío de mensajes.

- ci-cd/jenkins/Jenkinsfile
: Integración de notificaciones en el pipeline maestro con hotfix de resiliencia (try-catch) para evitar errores si las credenciales no están configuradas.

**2. Infraestructura:**

- infrastructure/docker/docker-compose.mock.yml
: Adición del servicio WAHA (puerto 3005) para soporte de notificaciones.

**3. Documentación:**

- ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
: Guía completa que incluye cómo obtener el chatId del grupo vía Swagger o logs.

- ci-cd/README.md
: Actualización con la sección de notificaciones.

## ✅ Verificación Realizada
- [ ✔ ] Validación manual del payload JSON mediante netcat en puerto 3005.
- [ ✔ ]  Prueba de resiliencia: El build termina correctamente (SKIP) cuando no existe la credencial en Jenkins.
<img width="669" height="369" alt="Screenshot from 2026-02-22 02-02-51" src="https://github.com/user-attachments/assets/a0a3932b-cf0b-4c04-8e0c-09940938ae1f" />

