### PR TITLE
fix(infra): habilitar acceso externo y credenciales para WAHA #10

### DIFF
--- a/infrastructure/docker/docker-compose.mock.yml
+++ b/infrastructure/docker/docker-compose.mock.yml
@@ -36,3 +36,7 @@ services:
     environment:
       - WAHA_LOG_LEVEL=info
       - WAHA_PRINT_QR=true
+      # Credenciales explícitas para acceso al Dashboard y Swagger
+      # Se configuran admin/admin para facilitar las pruebas en el entorno de mock
+      - WAHA_DASHBOARD_USER=admin
+      - WAHA_DASHBOARD_PASSWORD=admin

--- a/infrastructure/terraform/modules/aws-app-server/main.tf
+++ b/infrastructure/terraform/modules/aws-app-server/main.tf
@@ -66,6 +66,14 @@ resource "aws_security_group" "plan_b_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port   = 3005
+    to_port     = 3005
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "WhatsApp HTTP API (WAHA)"
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
## **📝 Descripción**
Este PR completa la configuración de infraestructura necesaria para que el bot de WhatsApp sea accesible y funcional desde el exterior.

## **🛠️ Cambios Realizados**
- **Cloud/Network (Terraform):** Se habilitó la regla de entrada para el puerto 3005 en el Security Group de AWS. Sin esto, el -dashboard era inaccesible.
- **Seguridad (Docker):** Se configuraron credenciales explícitas (admin/admin) en el archivo mock para asegurar el acceso al dashboard, evitando fallos con los valores por defecto del contenedor original.
