### PR TITLE
fix(infra): corregir nombre de variable para login de WAHA

### DIFF
--- a/infrastructure/docker/docker-compose.mock.yml
+++ b/infrastructure/docker/docker-compose.mock.yml
@@ -38,5 +38,5 @@ services:
       - WAHA_PRINT_QR=true
       # Credenciales explícitas para acceso al Dashboard y Swagger
       # Se configuran admin/admin para facilitar las pruebas en el entorno de mock
-      - WAHA_DASHBOARD_USER=admin
+      - WAHA_DASHBOARD_USERNAME=admin
       - WAHA_DASHBOARD_PASSWORD=admin


### PR DESCRIPTION
Se corrige el nombre de la variable de entorno  `WAHA_DASHBOARD_USER` por `WAHA_DASHBOARD_USERNAME` en el archivo de mocks.

## 🛠️ Razón del cambio
La versión actual de la imagen WAHA ignora la variable corta y, al no encontrar el username, genera una contraseña aleatoria en cada reinicio del contenedor, bloqueando el acceso administrativo con las credenciales configuradas (admin/admin).

## 
✅ Verificación
Verificado mediante logs del contenedor (docker logs) que el sistema ahora solicita las credenciales definidas por el usuario en lugar de las autogeneradas.

<img width="1207" height="355" alt="Screenshot from 2026-02-22 03-33-12" src="https://github.com/user-attachments/assets/347f4853-ddd9-41ae-85eb-f510e7991053" />
