### PR TITLE
fix(infra): asegurar acceso admin/admin en dashboard de WAHA #10

### DIFF
--- a/infrastructure/docker/docker-compose.mock.yml
+++ b/infrastructure/docker/docker-compose.mock.yml
@@ -38,5 +38,9 @@ services:
       - WAHA_PRINT_QR=true
       # Credenciales explícitas para acceso al Dashboard y Swagger
       # Se configuran admin/admin para facilitar las pruebas en el entorno de mock
+      - WAHA_DASHBOARD_ENABLED=true
       - WAHA_DASHBOARD_USERNAME=admin
       - WAHA_DASHBOARD_PASSWORD=admin
+      - WHATSAPP_SWAGGER_USERNAME=admin
+      - WHATSAPP_SWAGGER_PASSWORD=admin
+      - WAHA_API_KEY=admin


### PR DESCRIPTION
📝 Descripción
Este PR añade redundancia en las variables de entorno de autenticación para WAHA. 

🛠️ Cambios
- Se configuraron los prefijos `WAHA_` y `WHATSAPP_` simultáneamente en [docker-compose.mock.yml](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/Work%20simulation/equine-lead/infrastructure/docker/docker-compose.mock.yml:0:0-0:0).
- Se habilitó explícitamente `WAHA_DASHBOARD_ENABLED=true` y `WAHA_API_KEY=admin`.

Razón: Se observó en los logs que el contenedor ignoraba el prefijo WAHA_ en ciertas condiciones, generando claves aleatorias. Con esta redundancia se garantiza que 'admin/admin' sea la credencial de acceso definitiva.
