### PR TITLE
fix(infra): desactivar autenticación en dashboard de WAHA para entorno mock #10

### DIFF
--- a/infrastructure/docker/docker-compose.mock.yml
+++ b/infrastructure/docker/docker-compose.mock.yml
@@ -36,11 +36,9 @@ services:
     environment:
       - WAHA_LOG_LEVEL=info
       - WAHA_PRINT_QR=true
-      # Credenciales explícitas para acceso al Dashboard y Swagger
-      # Se configuran admin/admin para facilitar las pruebas en el entorno de mock
+      # Configuración de acceso para el Dashboard y Swagger
+      # Se desactiva la contraseña para facilitar las pruebas en el entorno de mock
       - WAHA_DASHBOARD_ENABLED=true
+      - WAHA_DASHBOARD_NO_PASSWORD=true
       - WAHA_DASHBOARD_USERNAME=admin
-      - WAHA_DASHBOARD_PASSWORD=admin
-      - WHATSAPP_SWAGGER_USERNAME=admin
-      - WHATSAPP_SWAGGER_PASSWORD=admin
       - WAHA_API_KEY=admin


### PR DESCRIPTION
## 📝 Descripción
Ajuste de infraestructura para garantizar el acceso al dashboard de WAHA. Se ha desactivado la autenticación por contraseña para el entorno de mock para evitar conflictos con la generación aleatoria de claves en la versión 2026.2.2.

## 🛠️ Cambios Realizados
- Docker Compose: Se añadió la variable `WAHA_DASHBOARD_NO_PASSWORD=true` en infrastructure/docker/docker-compose.mock.yml
- Se simplificó la configuración de variables eliminando redundancia innecesaria.