### PR TITLE
fix(ci): integrar credencial X-Api-Key y URL absoluta para notificaciones WAHA

### DIFF
--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -156,7 +156,7 @@ Hemos implementado un sistema de notificaciones en tiempo real para alertar al e
 
 ### **Componentes:**
 - **Script**: `ci-cd/jenkins/scripts/notify_whatsapp.sh`
-- **Docker**: Puerto `3000` en la instancia App Server.
+- **Docker**: Puerto `3005` en la instancia App Server.
 
 📖 **Guía de configuración**: [ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md](./jenkins/NOTIFICACIONES_WHATSAPP.md)
 

--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -134,8 +134,13 @@ pipeline {
             // Notificación WhatsApp (Issue #10)
             script {
                 try {
-                    withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
-                        sh './ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS ${BRANCH_NAME}'
+                    withEnv(["WAHA_URL=http://${APP_SERVER_IP}:3005"]) {
+                        withCredentials([
+                            string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT'),
+                            string(credentialsId: 'waha-api-key', variable: 'WAHA_API_KEY') // Necesita credencial waha-api-key = admin
+                        ]) {
+                            sh './ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS ${BRANCH_NAME}'
+                        }
                     }
                 } catch (Exception e) {
                     echo "⚠️ No se pudo enviar notificación de WhatsApp: ${e.message}"
@@ -151,8 +156,13 @@ pipeline {
             // Notificación WhatsApp (Issue #10)
             script {
                 try {
-                    withCredentials([string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT')]) {
-                        sh './ci-cd/jenkins/scripts/notify_whatsapp.sh FAILURE ${BRANCH_NAME}'
+                    withEnv(["WAHA_URL=http://${APP_SERVER_IP}:3005"]) {
+                        withCredentials([
+                            string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT'),
+                            string(credentialsId: 'waha-api-key', variable: 'WAHA_API_KEY') // Necesita credencial waha-api-key = admin
+                        ]) {
+                            sh './ci-cd/jenkins/scripts/notify_whatsapp.sh FAILURE ${BRANCH_NAME}'
+                        }
                     }
                 } catch (Exception e) {
                     echo "⚠️ No se pudo enviar notificación de WhatsApp: ${e.message}"

--- a/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
+++ b/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
@@ -11,10 +11,13 @@ docker compose -f docker-compose.mock.yml up -d waha
 ```
 
 ## 2. 📲 Vinculación de WhatsApp
-Una vez que el contenedor esté corriendo:
-1. Revisa los logs para ver el código QR: `docker logs -f equine-lead-waha`
-2. Abre WhatsApp en tu teléfono -> Dispositivos vinculados -> Vincular un dispositivo.
-3. Escanea el código QR que aparece en la terminal.
+Una vez que el contenedor esté corriendo, la vinculación se realiza desde el Dashboard visual:
+1. Accede al Dashboard: `http://[IP-DEL-SERVIDOR]:3005/dashboard`.
+2. En la sección **Sessions**, localiza la sesión `default` (si no existe, créala con ese nombre).
+3. Haz clic en el icono de **"Play"** (triángulo verde) para arrancar la sesión. El estado cambiará a `STARTING` y luego a `SCAN_QR`.
+4. Haz clic en el icono de la **cámara** (Screenshot) que aparecerá al lado del estado.
+5. Escanea el código QR con tu aplicación de WhatsApp (Dispositivos vinculados).
+6. Una vez escaneado, el estado pasará a `WORKING` o `CONNECTED` (en verde).
 
 ## 3. 🔑 Configuración en Jenkins
 Para que Jenkins pueda enviar mensajes, necesita el `chatId` real del destinatario (que no es lo mismo que un link de invitación).
@@ -23,13 +26,14 @@ Para que Jenkins pueda enviar mensajes, necesita el `chatId` real del destinatar
 Una vez vinculado el teléfono, tienes dos formas de obtener el ID:
 
 #### Opción A: Vía Swagger (Recomendado)
-1. Accede a la interfaz de WAHA en tu navegador: `http://[IP-DEL-SERVIDOR]:3005/`
-2. Busca el endpoint **`GET /api/chats`**.
-3. Haz clic en **"Try it out"** y luego en **"Execute"**.
-4. En la respuesta (Response body), busca el nombre de tu grupo o contacto.
-5. Copia el valor de la propiedad `"id"`. 
-   - 👥 Grupos: Tienen el formato `1203630245678@g.us`
-   - 👤 Contactos: Tienen el formato `51987654321@c.us`
+1. Accede a la interfaz de API Documentation: `http://[IP-DEL-SERVIDOR]:3005/`.
+2. **Autorización**: Haz clic en el botón superior **"Authorize"** (icono de candado).
+3. Escribe `admin` en el campo y haz clic en **"Authorize"**, luego en **"Close"**. Esto evitará el error `401 Unauthorized`.
+4. Busca la sección **`CHATS`** y el endpoint **`GET /api/{session}/chats`**.
+5. Haz clic en **"Try it out"**, escribe `default` en el campo `session` y dale a **"Execute"**.
+6. En el **Response body**, verás un JSON con la lista de tus chats.
+7. Identifica tu grupo por su nombre y copia el valor del campo `_serialized` o `id`.
+   - 👥 Ejemplo: `120363407034115167@g.us`
 
 #### Opción B: Vía Logs
 1. Ejecuta: `docker logs -f equine-lead-waha`
@@ -42,6 +46,21 @@ Una vez vinculado el teléfono, tienes dos formas de obtener el ID:
    - **ID**: `waha-recipient` (Debe ser exactamente este ID).
    - **Secret**: El `chatId` obtenido en el paso anterior.
    - **Description**: Recipiente de notificaciones WhatsApp EquineLead.
+
+## 4. 🧪 Pruebas y Verificación
+Para confirmar que todo funciona:
+1. Realiza un pequeño cambio en el código o documentación.
+2. Haz `git commit` y `git push` a cualquier rama que Jenkins vigile (ej: `dev`).
+3. Una vez que el pipeline termine, deberías recibir un mensaje en el grupo configurado.
+
+### Ejemplo de mensaje esperado:
+> *✅ EquineLead Notification*
+> -------------------------
+> *Estado:* ¡Build Exitoso!
+> *Rama:* feature/devops-automation
+> *Autor:* David Alejandro
+> -------------------------
+> _Enviado automáticamente por Jenkins_
 
 ## 📝 Notas Técnicas
 - **Transición a Producción**: Cuando dejen de usar `docker-compose.mock.yml`, simplemente copien la definición del servicio `waha` al `docker-compose.yml` final. El script de Jenkins seguirá funcionando igual.

--- a/ci-cd/jenkins/scripts/notify_whatsapp.sh
+++ b/ci-cd/jenkins/scripts/notify_whatsapp.sh
@@ -36,8 +36,9 @@ MESSAGE="*${ICON} ${PROJECT_NAME} Notification*
 _Enviado automáticamente por Jenkins_"
 
 # Enviar vía WAHA API
-curl -X POST "${WAHA_URL}/api/sendText" \
+curl -s -X POST "${WAHA_URL}/api/sendText" \
      -H "Content-Type: application/json" \
+     -H "X-Api-Key: ${WAHA_API_KEY}" \
      -d "{
            \"chatId\": \"${RECIPIENT}\",
            \"text\": \"${MESSAGE}\",


### PR DESCRIPTION
📝 Descripción
Este PR corrige el fallo en el envío de notificaciones de WhatsApp desde Jenkins hacia la API de WAHA, garantizando la seguridad y el enrutamiento correcto del tráfico.

🛠️ Cambios
- Se modificó [ci-cd/jenkins/scripts/notify_whatsapp.sh](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/Work%20simulation/equine-lead/ci-cd/jenkins/scripts/notify_whatsapp.sh:0:0-0:0) para incluir el Header `X-Api-Key` requerido por WAHA.
- Se actualizó el [Jenkinsfile](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/Work%20simulation/equine-lead/ci-cd/jenkins/Jenkinsfile:0:0-0:0) para que la variable `WAHA_URL` apunte explícitamente a la IP del servidor de App (`http://${APP_SERVER_IP}:3005`) en lugar de `localhost`.
- Se configuró la inyección de la credencial segura `waha-api-key` directamente en los stages de éxito y fallo.

Razón: Jenkins y el contenedor de WAHA operan en contextos de red distintos, y la configuración previa carecía de las credenciales rígidas (`admin`) exigidas por la versión actual del Dashboard.
