### PR TITLE
fix(ci): cambiar limpieza de workspace a 'cleanup' para asegurar envío de notificaciones

### DIFF
--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -169,7 +169,7 @@ pipeline {
                 }
             }
         }
-        always {
+        cleanup {
             echo '🧹 Limpiando workspace...'
             cleanWs()
         }


### PR DESCRIPTION
📝 Descripción
Este PR finaliza la estabilización del sistema de notificaciones de WhatsApp (WAHA), resolviendo un fallo de orden de ejecución en el pipeline Declarativo de Jenkins.

🛠️ Cambios
- Se modificó el bloque `always` del [Jenkinsfile](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/Work%20simulation/equine-lead/ci-cd/jenkins/Jenkinsfile:0:0-0:0) cambiándolo por el bloque `cleanup`.

Razón: El bloque `always` se ejecutaba antes de evaluar el estado global del build (`success` / `failure`), lo que causaba que el comando `cleanWs()` borrara el script `notify_whatsapp.sh` del entorno de trabajo *antes* de que Jenkins intentara ejecutarlo para notificar los resultados de los tests. Migrar esta acción a `cleanup` garantiza que la limpieza ocurra estrictamente al final.
