### PR TITLE
fix(ci): corregir formato JSON del mensaje WAHA y eliminar advertencias de interpolación

### DIFF
--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -134,14 +134,12 @@ pipeline {
             // Notificación WhatsApp (Issue #10)
             script {
                 try {
-                    withEnv(["WAHA_URL=http://${APP_SERVER_IP}:3005"]) {
                         withCredentials([
                             string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT'),
                             string(credentialsId: 'waha-api-key', variable: 'WAHA_API_KEY') // Necesita credencial waha-api-key = admin
                         ]) {
                             sh './ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS ${BRANCH_NAME}'
                         }
-                    }
                 } catch (Exception e) {
                     echo "⚠️ No se pudo enviar notificación de WhatsApp: ${e.message}"
                 }
@@ -156,14 +154,12 @@ pipeline {
             // Notificación WhatsApp (Issue #10)
             script {
                 try {
-                    withEnv(["WAHA_URL=http://${APP_SERVER_IP}:3005"]) {
                         withCredentials([
                             string(credentialsId: 'waha-recipient', variable: 'WAHA_RECIPIENT'),
                             string(credentialsId: 'waha-api-key', variable: 'WAHA_API_KEY') // Necesita credencial waha-api-key = admin
                         ]) {
                             sh './ci-cd/jenkins/scripts/notify_whatsapp.sh FAILURE ${BRANCH_NAME}'
                         }
-                    }
                 } catch (Exception e) {
                     echo "⚠️ No se pudo enviar notificación de WhatsApp: ${e.message}"
                 }

--- a/ci-cd/jenkins/scripts/notify_whatsapp.sh
+++ b/ci-cd/jenkins/scripts/notify_whatsapp.sh
@@ -6,7 +6,7 @@
 STATUS=$1
 BRANCH=$2
 PROJECT_NAME=${PROJECT_NAME:-"EquineLead"}
-WAHA_URL=${WAHA_URL:-"http://localhost:3005"}
+WAHA_URL=${WAHA_URL:-"http://${APP_SERVER_IP:-localhost}:3005"}
 WAHA_SESSION=${WAHA_SESSION:-"default"}
 RECIPIENT=${WAHA_RECIPIENT}
 
@@ -27,13 +27,7 @@ else
 fi
 
 LAST_COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an')
-MESSAGE="*${ICON} ${PROJECT_NAME} Notification*
--------------------------
-*Estado:* ${MSG}
-*Rama:* ${BRANCH}
-*Autor:* ${LAST_COMMIT_AUTHOR}
--------------------------
-_Enviado automáticamente por Jenkins_"
+MESSAGE="*${ICON} ${PROJECT_NAME} Notification*\n-------------------------\n*Estado:* ${MSG}\n*Rama:* ${BRANCH}\n*Autor:* ${LAST_COMMIT_AUTHOR}\n-------------------------\n_Enviado automáticamente por Jenkins_"
 
 # Enviar vía WAHA API
 curl -s -X POST "${WAHA_URL}/api/sendText" \


### PR DESCRIPTION
📝 Descripción
Este PR introduce correcciones en el formato del payload y en la seguridad del pipeline, en un esfuerzo por resolver los fallos de entrega de notificaciones de WhatsApp (WAHA) observados en el Build 14.

🛠️ Cambios
1. **Formato JSON Seguro:** Se modificó [notify_whatsapp.sh](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/Work%20simulation/equine-lead/ci-cd/jenkins/scripts/notify_whatsapp.sh:0:0-0:0) reemplazando los saltos de línea literales por secuencias de escape `\n` en la variable `MESSAGE`.
   - *Razón:* Los logs del Build 14 mostraron un error `400 Bad Request` ("Bad control character in string literal") desde WAHA, causado por los saltos de línea crudos rompiendo el JSON.
2. **Refactorización de Entorno Jenkins:** Se eliminó el bloque `withEnv` en las etapas `success`/`failure` del [Jenkinsfile](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/Work%20simulation/equine-lead/ci-cd/jenkins/Jenkinsfile:0:0-0:0) y se movió la lógica de construcción de URLs al script bash.
   - *Razón:* Jenkins arrojaba una advertencia de seguridad (Warning: insecure Groovy String interpolation) por inyectar un secreto (`APP_SERVER_IP`) directamente en groovy.

Estos cambios apuntan a resolver los últimos bloqueos identificados, aunque se requiere confirmación empírica en el siguiente build (Build 15).
