### PR TITLE
Fix: Corrección de Pipeline de Jenkins, orquestación Docker y notificaciones WAHA (AWS Plan B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ graph TB
 - **Scrapper (Rust 1.75.0)**: Extrae leads de fuentes públicas y los envía al API Backend — Jorge
 
 #### **Capa de Datos**
-- **PostgresSQL**: Base de datos principal. **C# es el único dueño de la persistencia**.
-- **Redis**: Caché para optimización de rendimiento 💡 _(pendiente de confirmación)_
+- **PostgresSQL 15**: Base de datos principal. **C# es el único dueño de la persistencia**.
+  - *Nota técnica:* Se utiliza un Volumen de Docker (`postgres_data`) para asegurar que los datos persistan en el disco duro del servidor (AWS o Local) incluso si el contenedor se recrea.
 
 #### **Filosofía de Desacoplamiento (Data Ownership)**
 Para evitar el patrón de "Monolito Distribuido", el sistema sigue estas reglas:

--- a/ci-cd/jenkins/CONFIGURACION_PASO_A_PASO.md
+++ b/ci-cd/jenkins/CONFIGURACION_PASO_A_PASO.md
@@ -39,8 +39,20 @@ Nuestros componentes necesitan variables de entorno (como `JWT_SECRET`, `DB_PASS
 4.  **ID**: Dale un nombre descriptivo (ej: `backend-jwt-secret`).
 5.  **Uso**: Estas IDs se inyectarán automáticamente en los contenedores de Docker durante el despliegue.
 
----
+### 📋 Inventario de Credenciales Actuales
+| ID Credencial | Tipo | Descripción |
+| :--- | :--- | :--- |
+| `github-auth` | Username with password | Token de acceso a GitHub / Personal Access Token |
+| `JWT_SECRET` | Secret text | Clave secreta para la autenticación del Backend C# |
+| `aws-app-server-key` | SSH Username with private key | Llave privada para acceder al servidor Ubuntu en AWS |
+| `app-server-ip` | Secret text | Dirección IP pública del App Server (Plan B) |
+| `waha-recipient` | Secret text | Número de destino para notificaciones de WhatsApp |
+| `waha-api-key` | Secret text | API Key para el servicio WAHA |
+| `db-name` | Secret text | Nombre de la base de datos PostgreSQL (`NoCountryE48DB`) |
+| `db-user` | Secret text | Usuario administrador de PostgreSQL (`postgres`) |
+| `db-password` | Secret text | Contraseña del usuario administrador (`postgres123`) |
 
+---
 ## 4. 🏗️ Creación del Multibranch Pipeline
 **Objetivo**: Crear el tablero de control automático para todas las ramas.
 

--- a/ci-cd/jenkins/Jenkinsfile
+++ b/ci-cd/jenkins/Jenkinsfile
@@ -86,36 +86,47 @@ pipeline {
             }
         }
         
-        stage('🚀 Deploy Mock to AWS') {
+        stage('🚀 Deploy to AWS (Plan B)') {
             when {
                 branch 'dev'
             }
             steps {
                 echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
-                echo '🚀 Desplegando Mock (Nginx) en AWS App Server Plan B...'
+                echo '🚀 Desplegando Aplicación Real en AWS App Server Plan B...'
                 echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
-                withCredentials([sshUserPrivateKey(
-                    credentialsId: 'aws-app-server-key',
-                    keyFileVariable: 'SSH_KEY_FILE',
-                    usernameVariable: 'SSH_USER'
-                )]) {
+                withCredentials([
+                    sshUserPrivateKey(credentialsId: 'aws-app-server-key', keyFileVariable: 'SSH_KEY_FILE', usernameVariable: 'SSH_USER'),
+                    string(credentialsId: 'postgres-db', variable: 'DB_NAME'),
+                    string(credentialsId: 'postgres-user', variable: 'DB_USER'),
+                    string(credentialsId: 'postgres-password', variable: 'DB_PASS')
+                ]) {
                     sh '''
                         TARGET="${APP_SERVER_USER}@${APP_SERVER_IP}"
-                        COMPOSE_FILE="infrastructure/docker/docker-compose.mock.yml"
                         SSH_OPTS="-i $SSH_KEY_FILE -o StrictHostKeyChecking=no"
 
-                        echo ">>> Copiando docker-compose.mock.yml a ${TARGET}..."
-                        scp $SSH_OPTS \
-                            $COMPOSE_FILE \
-                            $TARGET:/home/ubuntu/docker-compose.mock.yml
+                        echo ">>> Sincronizando código fuente y configuración a ${TARGET}..."
+                        # Sincronizar directorios necesarios y el compose principal
+                        scp $SSH_OPTS docker-compose.yml ${TARGET}:/home/ubuntu/
+                        scp $SSH_OPTS -r src infrastructure ${TARGET}:/home/ubuntu/
 
-                        echo ">>> Ejecutando deploy en ${TARGET}..."
+                        echo ">>> Generando archivo .env con secretos en ${TARGET}..."
                         ssh $SSH_OPTS $TARGET "
-                            docker compose -f /home/ubuntu/docker-compose.mock.yml up -d --remove-orphans
-                            echo '--- Estado de contenedores ---'
+                            echo 'POSTGRES_DB=${DB_NAME}' > /home/ubuntu/.env
+                            echo 'POSTGRES_USER=${DB_USER}' >> /home/ubuntu/.env
+                            echo 'POSTGRES_PASSWORD=${DB_PASS}' >> /home/ubuntu/.env
+                            echo 'DB_HOST=db' >> /home/ubuntu/.env
+                            echo 'DB_PORT=5432' >> /home/ubuntu/.env
+                            echo 'DATASCIENCE_BASEURL=http://data-science:8090' >> /home/ubuntu/.env
+                        "
+
+                        echo ">>> Ejecutando build y despliegue en ${TARGET}..."
+                        ssh $SSH_OPTS $TARGET "
+                            cd /home/ubuntu
+                            docker compose up -d --build --remove-orphans
+                            echo '--- Estado de contenedores reales ---'
                             docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
                         "
-                        echo "✅ Mock desplegado en http://${APP_SERVER_IP}"
+                        echo "✅ Aplicación desplegada en http://${APP_SERVER_IP}:5286"
                     '''
                 }
             }

--- a/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
+++ b/ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md
@@ -2,7 +2,10 @@
 
 Esta guía explica cómo configurar el sistema de notificaciones automáticas para Jenkins usando **WAHA (WhatsApp HTTP API)**.
 
+---
+
 ## 1. 🚀 Despliegue del Servicio
+
 El servicio WAHA debe estar corriendo en la instancia de Oracle Cloud (App Server).
 
 ```bash
@@ -10,8 +13,12 @@ cd infrastructure/docker
 docker compose -f docker-compose.mock.yml up -d waha
 ```
 
+---
+
 ## 2. 📲 Vinculación de WhatsApp
+
 Una vez que el contenedor esté corriendo, la vinculación se realiza desde el Dashboard visual:
+
 1. Accede al Dashboard: `http://[IP-DEL-SERVIDOR]:3005/dashboard`.
 2. En la sección **Sessions**, localiza la sesión `default` (si no existe, créala con ese nombre).
 3. Haz clic en el icono de **"Play"** (triángulo verde) para arrancar la sesión. El estado cambiará a `STARTING` y luego a `SCAN_QR`.
@@ -19,10 +26,14 @@ Una vez que el contenedor esté corriendo, la vinculación se realiza desde el D
 5. Escanea el código QR con tu aplicación de WhatsApp (Dispositivos vinculados).
 6. Una vez escaneado, el estado pasará a `WORKING` o `CONNECTED` (en verde).
 
+---
+
 ## 3. 🔑 Configuración en Jenkins
+
 Para que Jenkins pueda enviar mensajes, necesita el `chatId` real del destinatario (que no es lo mismo que un link de invitación).
 
 ### Cómo obtener el `chatId` (ID del Grupo o Chat)
+
 Una vez vinculado el teléfono, tienes dos formas de obtener el ID:
 
 #### Opción A: Vía Swagger (Recomendado)
@@ -40,51 +51,126 @@ Una vez vinculado el teléfono, tienes dos formas de obtener el ID:
 2. Escribe cualquier mensaje en el grupo de WhatsApp.
 3. En la terminal verás aparecer un JSON del mensaje recibido. Busca el campo `"from"` o `"chatId"`.
 
-### Configuración de la Credencial
-1. Ir a **Manage Jenkins** > **Credentials**.
-2. Añadir una nueva credencial de tipo **Secret text**:
-   - **ID**: `waha-recipient` (Debe ser exactamente este ID).
-   - **Secret**: El `chatId` obtenido en el paso anterior.
-   - **Description**: Recipiente de notificaciones WhatsApp EquineLead.
+### Configuración de Credenciales en Jenkins
 
-## 4. 🧪 Pruebas y Verificación
+Ir a **Manage Jenkins → Credentials** y añadir las siguientes credenciales de tipo **Secret text**:
+
+| ID | Secret | Descripción |
+|----|--------|-------------|
+| `waha-recipient` | `chatId` obtenido arriba | Destinatario de las notificaciones (grupo o número) |
+| `waha-api-key`   | API key de WAHA (valor: `admin` por defecto) | Autenticación con el servidor WAHA |
+
+---
+
+## 4. 📜 Cómo Funciona el Script
+
+El script se encuentra en: `ci-cd/jenkins/scripts/notify_whatsapp.sh`
+
+### Firma de invocación
+
+```bash
+./notify_whatsapp.sh <STATUS> [BRANCH] [COMMIT_HASH] [BUILD_REPORT] [TEST_REPORT]
+```
+
+| Parámetro | Obligatorio | Descripción |
+|-----------|-------------|-------------|
+| `STATUS` | ✅ Sí | `SUCCESS` o `FAILURE` |
+| `BRANCH` | No | Nombre de la rama (si se omite, lo detecta vía `git`) |
+| `COMMIT_HASH` | No | Hash corto del commit (si se omite, lo detecta vía `git`) |
+| `BUILD_REPORT` | No | Ruta al archivo `builds_report.md` generado por Jenkins |
+| `TEST_REPORT`  | No | Ruta al archivo `tests_report.md` generado por Jenkins |
+
+**Ejemplo real desde el `Jenkinsfile`:**
+```bash
+./ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS "dev" "a3f9c21" builds_report.md tests_report.md
+```
+
+### Variables de entorno requeridas
+
+| Variable | Fuente | Descripción |
+|----------|--------|-------------|
+| `WAHA_URL` | Env Jenkins o default `http://localhost:3005` | URL base del servidor WAHA |
+| `WAHA_SESSION` | Env Jenkins o default `default` | Nombre de la sesión WAHA activa |
+| `WAHA_RECIPIENT` | Credencial Jenkins `waha-recipient` | `chatId` del destinatario |
+| `WAHA_API_KEY` | Credencial Jenkins `waha-api-key` | API key del servidor WAHA |
+| `PROJECT_NAME` | Env Jenkins o default `EquineLead` | Nombre que aparece en el mensaje |
+
+---
+
+## 5. 🔄 Flujo Interno del Script
+
+```
+notify_whatsapp.sh
+│
+├── 1. Detecta rama, commit y autor (vía git o parámetros)
+│
+├── 2. upload_to_dpaste()
+│      ├── Si se pasó BUILD_REPORT → sube a dpaste.com (expira 7 días) → guarda URL
+│      └── Si se pasó TEST_REPORT  → sube a dpaste.com (expira 7 días) → guarda URL
+│
+├── 3. Construye el mensaje de WhatsApp con:
+│      ├── Ícono ✅ / ❌ según STATUS
+│      ├── Rama, Autor, Fecha (zona horaria Perú GMT-5), Commit
+│      ├── Link 📦 Compilación → URL de dpaste (si existe)
+│      ├── Link 🧪 Tests       → URL de dpaste (si existe)
+│      └── Link 🔗 Log Jenkins (IP fija del servidor)
+│
+└── 4. send_text() → POST a WAHA /api/sendText con el mensaje construido
+```
+
+> **Nota**: El script también contiene la función `send_file()` (envío de archivos adjuntos vía `/api/sendFile` con codificación base64 en Python), pero actualmente **no se invoca** en el flujo principal. Está disponible para activarse si se decide enviar los `.md` directamente como adjuntos en lugar de links.
+
+---
+
+## 6. 📨 Ejemplo de Mensaje Enviado
+
+```
+✅ EquineLead | Reporte Generado
+━━━━━━━━━━━━━━━━━━━━
+*Rama:* dev
+*Autor:* Diego
+*Fecha:* 2026-02-25 20:35:10 (PE)
+*Commit:* a3f9c21
+
+📦 *Compilación:* https://dpaste.com/ABCDEF
+🧪 *Tests:* https://dpaste.com/GHIJKL
+
+🔗 *Log Jenkins:* http://[IP-DE-JENKINS]:8080/
+
+_Enviado automáticamente por Jenkins_
+```
+
+> Los links de dpaste contienen el contenido completo de `builds_report.md` y `tests_report.md` en texto plano, y expiran en **7 días**.
+
+---
+
+## 7. 🧪 Pruebas y Verificación
+
 Para confirmar que todo funciona:
 1. Realiza un pequeño cambio en el código o documentación.
 2. Haz `git commit` y `git push` a cualquier rama que Jenkins vigile (ej: `dev`).
-3. Una vez que el pipeline termine, deberías recibir un mensaje en el grupo configurado.
+3. Una vez que el pipeline termine, deberías recibir un mensaje en el grupo configurado con los links de compilación y tests.
 
-### Ejemplo de mensaje esperado:
-> *✅ EquineLead Notification*
->
-> *Estado:* ¡Build Exitoso!
-> *Rama:* dev
-> *Autor:* Diego
-> *Fecha de testeo:* 2026-02-23 14:10:20
-> *Commit:* 7a2b3c4
->
-> *📋 RESUMEN DETALLADO:*
-> ```
-> *📦 RESUMEN DE COMPILACIÓN*
-> ▶ Verificando: Backend C# ... ✅
-> ▶ Verificando: Data Science ... ❌
-> Total: 4 componentes | Fallados: 1
->
-> *🧪 RESUMEN DE TESTS (DATA SCIENCE)*
->   🔍 Health Check:  FALLIDO
->   🧪 Unit Tests:    EXITOSO
-> ❌ [Data Science] ALGUNOS TESTS FALLARON
-> ```
->
-> *🔗 Log Completo:*
-> http://129.151.114.218:8080/
->
-> _Enviado automáticamente por Jenkins_
+**Prueba manual desde el servidor de Jenkins:**
+```bash
+export WAHA_RECIPIENT="120363407034115167@g.us"
+export WAHA_API_KEY="admin"
+export WAHA_URL="http://[IP-DEL-SERVIDOR-WAHA]:3005"
+
+./ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS "dev" "abc1234" builds_report.md tests_report.md
+```
+
+---
 
 ## 💡 Tips de Uso
-- **Enlace Clickable**: Si el enlace a Jenkins no aparece en azul, es una medida de seguridad de WhatsApp. Simplemente **agrega el número a tus contactos** o **responde al mensaje** (escribe "OK") para habilitar los hipervínculos.
-- **Formato Limpio**: El sistema elimina automáticamente códigos de color (ANSI) y tiempos de ejecución para facilitar la lectura en móviles.
+
+- **Links no clickables**: Si los links de dpaste no aparecen en azul, agrega el número a tus contactos o responde al mensaje para habilitar hipervínculos en WhatsApp.
+- **dpaste expira**: Los reportes subidos a dpaste.com se eliminan automáticamente a los 7 días. Son solo para revisión inmediata del build.
+- **Cambio de IP del servidor WAHA**: Si WAHA y Jenkins están en servidores distintos, actualiza la variable `WAHA_URL` como variable de entorno global en Jenkins (**Manage Jenkins → Configure System → Global properties → Environment variables**).
+
+---
 
 ## 📝 Notas Técnicas
-- **Transición a Producción**: Cuando dejen de usar `docker-compose.mock.yml`, simplemente copien la definición del servicio `waha` al `docker-compose.yml` final. El script de Jenkins seguirá funcionando igual.
-- El script de notificación se encuentra en: `ci-cd/jenkins/scripts/notify_whatsapp.sh`.
-- La URL por defecto es `http://localhost:3005`. Si Jenkins y WAHA están en servidores distintos, debes actualizar la variable `WAHA_URL` en el script o como variable de entorno en Jenkins.
+
+- **Transición a Producción**: Cuando dejen de usar `docker-compose.mock.yml`, copien la definición del servicio `waha` al `docker-compose.yml` final. El script de Jenkins seguirá funcionando igual sin cambios.
+- **send_file() activable**: Si en el futuro se prefiere enviar los reportes como archivos adjuntos (en lugar de links), descomentar/llamar a `send_file "$BUILD_REPORT"` y `send_file "$TEST_REPORT"` al final del script, después de `send_text`.

--- a/ci-cd/jenkins/scripts/notify_whatsapp.sh
+++ b/ci-cd/jenkins/scripts/notify_whatsapp.sh
@@ -17,11 +17,21 @@ TEST_REPORT=$5
 
 PROJECT_NAME=${PROJECT_NAME:-"EquineLead"}
 WAHA_URL=${WAHA_URL:-"http://${APP_SERVER_IP:-localhost}:3005"}
+WAHA_URL="${WAHA_URL%/}" # Elimina slash final si existe para evitar //api
 WAHA_SESSION=${WAHA_SESSION:-"default"}
 RECIPIENT=${WAHA_RECIPIENT}
 
 if [ -z "$STATUS" ]; then
     echo "Uso: $0 <STATUS> [BRANCH] [COMMIT_HASH] [BUILD_REPORT] [TEST_REPORT]"
+    exit 1
+fi
+
+# Validación de variables críticas
+ERROR=0
+if [ -z "$WAHA_RECIPIENT" ]; then echo "❌ Error: Variable WAHA_RECIPIENT no definida."; ERROR=1; fi
+if [ -z "$WAHA_API_KEY" ]; then echo "❌ Error: Variable WAHA_API_KEY no definida."; ERROR=1; fi
+if [ "$ERROR" -eq 1 ]; then
+    echo "⚠️ Por favor, exporta las variables antes de ejecutar el script."
     exit 1
 fi
 
@@ -34,17 +44,40 @@ AUTHOR=$(git log -1 --pretty=format:'%an')
 TIMEZONE_DATE=$(TZ="America/Lima" date "+%Y-%m-%d %H:%M:%S")
 SHORT_COMMIT=${COMMIT_HASH:-$(git rev-parse --short HEAD)}
 
-# 1. Construcción del Mensaje de Resumen
+# 1. Subir reportes a dpaste.com y construir URLs
+upload_to_dpaste() {
+    local file_path="$1"
+    if [ -f "$file_path" ]; then
+        local url
+        url=$(curl -s --max-time 15 -X POST "https://dpaste.com/api/v2/" \
+             --data-urlencode "content@$file_path" \
+             -d "syntax=text&expiry_days=7")
+        echo "$url"
+    else
+        echo ""
+    fi
+}
+
+echo "Subiendo reportes a dpaste.com..."
+BUILD_URL=""
+TEST_URL=""
+[ ! -z "$BUILD_REPORT" ] && BUILD_URL=$(upload_to_dpaste "$BUILD_REPORT")
+[ ! -z "$TEST_REPORT" ]  && TEST_URL=$(upload_to_dpaste "$TEST_REPORT")
+
+# 2. Construcción del Mensaje de Resumen con links
 MESSAGE="*${ICON} ${PROJECT_NAME}* | Reporte Generado\n"
-MESSAGE+="━━━━━━━━━━━━━━━━━━━━\n"
+MESSAGE+="━━━━━━━━━━━━━━━━━\n"
 MESSAGE+="*Rama:* ${BRANCH}\n"
 MESSAGE+="*Autor:* ${AUTHOR}\n"
 MESSAGE+="*Fecha:* ${TIMEZONE_DATE} (PE)\n"
 MESSAGE+="*Commit:* ${SHORT_COMMIT}\n\n"
-MESSAGE+="📂 *Reportes adjuntos debajo:*\n"
-MESSAGE+="• Reporte de Compilación\n"
-MESSAGE+="• Reporte de Ejecución de Tests\n\n"
-MESSAGE+="🔗 *Log Jenkins:* http://129.151.114.218:8080/\n"
+if [ ! -z "$BUILD_URL" ]; then
+    MESSAGE+="📦 *Compilación:* ${BUILD_URL}\n"
+fi
+if [ ! -z "$TEST_URL" ]; then
+    MESSAGE+="🧪 *Tests:* ${TEST_URL}\n"
+fi
+MESSAGE+="\n🔗 *Log Jenkins:* http://129.151.114.218:8080/\n"
 MESSAGE+="\n_Enviado automáticamente por Jenkins_"
 
 # Función para enviar texto
@@ -54,57 +87,74 @@ send_text() {
     escaped_text=$(echo -e "$text" | python3 -c 'import json, sys; print(json.dumps(sys.stdin.read()))')
     
     echo ">>> Enviando mensaje de texto..."
-    curl -s -X POST "${WAHA_URL}/api/sendText" \
+    local response
+    response=$(curl -s -X POST "${WAHA_URL}/api/sendText" \
          -H "Content-Type: application/json" \
          -H "X-Api-Key: ${WAHA_API_KEY}" \
          -d "{
            \"chatId\": \"$RECIPIENT\",
            \"text\": $escaped_text,
            \"session\": \"$WAHA_SESSION\"
-         }"
-    echo -e "\n"
+         }")
+    echo -e ">>> Respuesta API: $response\n"
 }
 
-# Función para enviar archivo (base64)
+# Función para enviar archivo (base64 via Python para evitar problemas de shell)
 send_file() {
     local file_path="$1"
     local filename=$(basename "$file_path")
-    
+
     echo ">>> Verificando archivo: $file_path"
     if [ -f "$file_path" ]; then
         ls -lh "$file_path"
-        local b64_data=$(base64 -w 0 "$file_path")
-        
         echo ">>> Enviando adjunto: $filename ..."
-        curl -s -X POST "${WAHA_URL}/api/sendFile" \
-             -H "Content-Type: application/json" \
-             -H "X-Api-Key: ${WAHA_API_KEY}" \
-             -d "{
-               \"chatId\": \"$RECIPIENT\",
-               \"file\": {
-                 \"mimetype\": \"application/octet-stream\",
-                 \"filename\": \"$filename\",
-                 \"data\": \"$b64_data\"
-               },
-               \"session\": \"$WAHA_SESSION\"
-             }"
-        echo -e "\n"
+
+        # Python construye el JSON y hace el POST directamente para evitar
+        # problemas de escape de caracteres en bloques grandes de base64
+        python3 - <<PYEOF
+import base64, json, urllib.request, os
+
+file_path = "$file_path"
+filename  = "$filename"
+waha_url  = os.environ.get("WAHA_URL", "http://localhost:3005")
+api_key   = os.environ.get("WAHA_API_KEY", "")
+recipient = os.environ.get("WAHA_RECIPIENT", "")
+session   = os.environ.get("WAHA_SESSION", "default")
+
+with open(file_path, "rb") as f:
+    b64 = base64.b64encode(f.read()).decode()
+
+payload = json.dumps({
+    "session": session,
+    "chatId": recipient,
+    "caption": filename,
+    "file": {
+        "mimetype": "application/octet-stream",
+        "filename": filename,
+        "data": b64
+    }
+}).encode("utf-8")
+
+req = urllib.request.Request(
+    f"{waha_url}/api/sendFile",
+    data=payload,
+    headers={
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key
+    }
+)
+try:
+    with urllib.request.urlopen(req) as resp:
+        print(">>> Respuesta API:", resp.read().decode())
+except Exception as e:
+    print(">>> Error al enviar:", str(e))
+PYEOF
+
     else
         echo "⚠️ Error: El archivo $file_path no existe o está vacío."
     fi
 }
 
 echo "Enviando notificación a WhatsApp..."
-
-# Enviar resumen primero
 send_text "$MESSAGE"
-
-# Pequeña pausa para asegurar el orden en WhatsApp
-sleep 2
-
-# Enviar reportes
-if [ ! -z "$BUILD_REPORT" ]; then send_file "$BUILD_REPORT"; fi
-sleep 1
-if [ ! -z "$TEST_REPORT" ]; then send_file "$TEST_REPORT"; fi
-
 echo "✅ Proceso de notificación finalizado."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      # ⚠️ PERSISTENCIA: Vincula los datos de la DB al disco del host (AWS/Local).
+      # Permite que los datos (ej: 100k leads) sobrevivan a reinicios o borrado de contenedores.
       - postgres_data:/var/lib/postgresql/data
     networks:
       - equine-net
@@ -52,8 +54,9 @@ services:
     container_name: equine-backend
     restart: always
     ports:
-      - "5286:80"
+      - "80:80"
     environment:
+      - ASPNETCORE_HTTP_PORTS=80
       # Connection string construida con las variables del .env
       - ConnectionStrings__DefaultConnection=Host=${DB_HOST};Port=${DB_PORT};Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
       # URL del servicio de Data Science (nombre del servicio en la red interna)

--- a/docs/guides/VERIFICACION_LOCAL_DESPLIEGUE.md
+++ b/docs/guides/VERIFICACION_LOCAL_DESPLIEGUE.md
@@ -1,0 +1,84 @@
+# 🔬 Guía de Verificación Local de Despliegue
+
+Esta guía detalla cómo validar cada componente de la nueva infraestructura de despliegue sin necesidad de realizar constantes commits o disparar el pipeline de Jenkins innecesariamente.
+
+> [!IMPORTANT]
+> Todos los comandos de esta guía deben ejecutarse desde la raíz del proyecto: `/home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead`.
+
+---
+
+## 1. 🐳 Validación de Orquestación (Docker Compose)
+**Objetivo:** Asegurar que el `docker-compose.yml` y los `Dockerfile` de los servicios reales funcionan y se comunican entre sí.
+
+### Pasos:
+1.  **Preparar Entorno:**
+    - Asegúrate de tener el archivo `.env` en la raíz (usa `.env.example` como base si no lo tienes).
+    - Verifica que las credenciales de `POSTGRES_PASSWORD` en tu `.env` sean las que quieres usar localmente.
+2.  **Levantar Servicios:**
+    ```bash
+    docker compose up -d --build
+    ```
+3.  **Verificación:**
+    - `docker ps`: Deben aparecer `equine-backend`, `equine-data-science` y `equine-postgres`.
+    - **Backend:** Accede a `http://localhost/swagger` (puerto 80 por defecto).
+    - **Data Science:** Accede a `http://localhost:8090`.
+
+---
+
+## 2. 📲 Validación de Notificaciones WhatsApp
+**Objetivo:** Probar que el script de notificación puede subir reportes a dpaste y enviarlos vía WAHA.
+
+### Pasos:
+1.  **Configurar Variables:** (Usa tus credenciales de prueba)
+    ```bash
+    export WAHA_RECIPIENT="120363407034115167@g.us"
+    export WAHA_API_KEY="admin"
+    export WAHA_URL="http://44.202.43.214:3005/"
+    ```
+    ℹ️ Si este ID no funciona, obtén el actual de tu grupo siguiendo la:
+    [Guía de Obtención de chatId](../../ci-cd/jenkins/NOTIFICACIONES_WHATSAPP.md#3-🔑-configuración-en-jenkins)
+
+2.  **Generar Reportes Reales:**
+    (Esto ejecutará los scripts de auditoría del proyecto y guardará el resultado en archivos `.md` limpios).
+    ```bash
+    # Generar reporte de compilación (limpiando colores ANSI)
+    ./tests/scripts/check_builds.sh | sed -r 's/\x1b\[[0-9;]*m//g' > builds_report.md
+    
+    # Generar reporte de todos los tests (limpiando colores ANSI)
+    ./tests/scripts/run_all_tests.sh | sed -r 's/\x1b\[[0-9;]*m//g' > tests_report.md
+    ```
+3.  **Ejecutar Script de Notificación:**
+    ```bash
+    ./ci-cd/jenkins/scripts/notify_whatsapp.sh SUCCESS "test-real" "local-hash" builds_report.md tests_report.md
+    ```
+4.  **Verificación:**
+    - Debes recibir un mensaje en WhatsApp con dos enlaces de `dpaste.com`.
+    - Abre los enlaces y verifica que el contenido sea el de tus archivos.
+
+---
+
+## 3. 🚀 Validación de Despliegue Manual a AWS
+**Objetivo:** Confirmar que la sincronización de archivos y la ejecución remota de Docker funcionan en el servidor final.
+
+### Pasos:
+1.  **Sincronizar Archivos:**
+    ```bash
+    # Reemplaza 'tu-clave.pem' por tu llave SSH real
+    scp -i tu-clave.pem .env docker-compose.yml ubuntu@44.202.43.214:/home/ubuntu/
+    scp -i tu-clave.pem -r src infrastructure ubuntu@44.202.43.214:/home/ubuntu/
+    ```
+2.  **Ejecución Remota:**
+    ```bash
+    ssh -i tu-clave.pem ubuntu@44.202.43.214 "cd /home/ubuntu && docker compose up -d --build"
+    ```
+3.  **Verificación:**
+    - Accede a `http://44.202.43.214/WeatherForecast` para confirmar que el Backend está arriba y retorna datos JSON.
+    - (Nota: Si accedías por el puerto 5286, este está bloqueado por el Firewall de AWS, por lo que usamos el puerto 80 por defecto).
+
+---
+
+## 🛠️ Solución de Problemas Comunes
+
+- **Error en SCP/SSH:** Verifica que la IP del servidor no haya cambiado y que tu llave `.pem` tenga permisos `400`.
+- **Contenedores fallan en AWS:** Revisa los logs remotos con `docker compose logs -f`.
+- **Links de WhatsApp no cargan:** Asegúrate de que el servidor de Jenkins (o tu PC) tenga salida a internet para llegar a `https://dpaste.com`.

--- a/src/backend-csharp/Program.cs
+++ b/src/backend-csharp/Program.cs
@@ -44,13 +44,24 @@ builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
+// Habilitar Swagger siempre en este hito para validación
+app.UseSwagger();
+app.UseSwaggerUI(c =>
+{
+    c.SwaggerEndpoint("/swagger/v1/swagger.json", "EquineLead API V1");
+    c.RoutePrefix = "swagger"; // Sirve en /swagger
+});
+
+app.UseStaticFiles(); // Necesario para el UI de Swagger en algunos entornos
+
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    // Bloque adicional si es necesario
 }
-
-app.UseHttpsRedirection();
+else
+{
+    app.UseHttpsRedirection();
+}
 app.UseAuthorization();
 app.MapControllers();
 app.Run();

--- a/src/data-science/Dockerfile
+++ b/src/data-science/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copiar dependencias e instalarlas primero (cache de capas)
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --default-timeout=100 -r requirements.txt
 
 # Copiar el código fuente del módulo
 COPY . ./


### PR DESCRIPTION
## 📝 Descripción
Este Pull Request implementa el despliegue automatizado de los servicios reales (`Backend`, `Data Science`, `PostgreSQL`) en la instancia de AWS a través de Jenkins (Plan B), reemplazando los contenedores de prueba (mocks). 

Además, estabiliza la orquestación local con Docker Compose, soluciona problemas de red en el servidor remoto y mejora la robustez del script de notificaciones de WhatsApp.

## 🛠️ Cambios Realizados

**1. Jenkins y Pipeline (Plan B)**
* **Jenkinsfile actualizado:** Se modificó el pipeline para sincronizar el código fuente (`src/`, `infrastructure/`) y desplegar los servicios reales en lugar de mocks.
* **Inyección de Secretos:** Se implementó la recuperación segura de credenciales desde Jenkins para inyectarlas dinámicamente en el archivo [.env](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/.env:0:0-0:0) del servidor AWS.

**2. Orquestación y Docker**
* **Ajuste de Puertos (AWS Security Group):** Se actualizó el [docker-compose.yml](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/docker-compose.yml:0:0-0:0) local para mapear el backend al puerto `80:80` de manera definitiva, alineándolo con las reglas del Firewall/Security Group de AWS (que bloqueaba el puerto 5286).
* **Fix Timeout Data Science:** Se aumentó el timeout de `pip` (`--default-timeout=100`) en el Dockerfile de Python para evitar errores de red al descargar paquetes pesados (ej. `matplotlib`).

**3. Backend (C#)**
* **Desactivación de HTTPS Redirection:** Se desactivó el recargo de HTTPS en entornos de desarrollo/Docker en [Program.cs](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/src/backend-csharp/Program.cs:0:0-0:0) para prevenir bloqueos de conectividad interna.
* **Habilitación de Swagger:** Se expuso de manera global el Swagger y los archivos estáticos en [Program.cs](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/src/backend-csharp/Program.cs:0:0-0:0) para facilitar la verificación post-despliegue.

**4. Notificaciones WhatsApp (WAHA)**
* **Manejo de URLs:** Se corrigió un bug lógico en [notify_whatsapp.sh](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/ci-cd/jenkins/scripts/notify_whatsapp.sh:0:0-0:0) que generaba rutas inválidas (`//api/sendText`) al sanitizar la variable `WAHA_URL`.
* **Validación de variables:** Se implementó `fail-fast` si faltan las variables críticas (`WAHA_RECIPIENT`, `WAHA_API_KEY`).
* **Reportes en nube:** El script ahora se integra exitosamente con `dpaste.com` para compilar los [.md](cci:7://file:///home/degops/.gemini/antigravity/brain/50580ac4-0353-4ff0-be91-163a50398446/task.md:0:0-0:0) y enviar los enlaces limpios y clickeables en el mensaje de WhatsApp.

**5. Documentación**
* **Guías de Uso:** Se creó/actualizó la guía [VERIFICACION_LOCAL_DESPLIEGUE.md](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/docs/guides/VERIFICACION_LOCAL_DESPLIEGUE.md:0:0-0:0) con los pasos exactos para reproducir las verificaciones localmente y sincronizar el [.env](cci:7://file:///home/degops/Projects/Repositorios/repo_NoCountryChallenges/work-simulation/equine-lead/.env:0:0-0:0) en testeos manuales.

## 🧪 Pruebas Realizadas
- [x] **Local:** Los servicios se comunican correctamente dentro de la red Docker (`equine-net`).
- [x] **AWS Manual:** Los contenedores levantan exitosamente (Estado `Healthy` en la DB) y el puerto 80 del Backend responde hacia el exterior.
- [x] **Notificaciones:** Mensajes de estado recibidos en el grupo de WhatsApp con links reales a los reportes de compildos y tests.
